### PR TITLE
Add flag for output format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/API_Throughput_*.md

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -33,7 +33,7 @@ func (benchmark *Benchmark) runCli() error {
 			concurrency,
 			result.GenerationSpeed,
 			result.PromptThroughput,
-			result.MaxTtft,
+			result.MinTtft,
 			result.MaxTtft,
 		)
 
@@ -42,7 +42,7 @@ func (benchmark *Benchmark) runCli() error {
 			concurrency,
 			result.GenerationSpeed,
 			result.PromptThroughput,
-			result.MaxTtft,
+			result.MinTtft,
 			result.MaxTtft,
 		})
 	}

--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/Yoosu-L/llmapibenchmark/internal/utils"
+)
+
+func (setup *BenchmarkSetup) runBenchmarkCli() error {
+	// Test latency
+	latency, err := utils.TestSpeedWithSystemProxy(setup.BaseURL, 5)
+	if err != nil {
+		return fmt.Errorf("latency test error: %v", err)
+	}
+
+	// Print benchmark header
+	utils.PrintBenchmarkHeader(setup.ModelName, setup.InputTokens, setup.MaxTokens, latency)
+
+	// Print table header
+	fmt.Println("| Concurrency | Generation Throughput (tokens/s) |  Prompt Throughput (tokens/s) | Min TTFT (s) | Max TTFT (s) |")
+	fmt.Println("|-------------|----------------------------------|-------------------------------|--------------|--------------|")
+
+	// Test each concurrency level and print results
+	var results [][]interface{}
+	for _, concurrency := range setup.ConcurrencyLevels {
+		measurement, err := setup.measureConcurrency(latency, concurrency)
+		if err != nil {
+			return fmt.Errorf("concurrency %d measurement error: %v", concurrency, err)
+		}
+
+		// Print current results
+		fmt.Printf("| %11d | %32.2f | %29.2f | %12.2f | %12.2f |\n",
+			concurrency,
+			measurement.GenerationSpeed,
+			measurement.PromptThroughput,
+			measurement.MaxTtft,
+			measurement.MaxTtft,
+		)
+
+		// Save results for later
+		results = append(results, []interface{}{
+			concurrency,
+			measurement.GenerationSpeed,
+			measurement.PromptThroughput,
+			measurement.MaxTtft,
+			measurement.MaxTtft,
+		})
+	}
+
+	fmt.Println("\n================================================================================================================")
+
+	// Save results to Markdown
+	utils.SaveResultsToMD(results, setup.ModelName, setup.InputTokens, setup.MaxTokens, latency)
+
+	return nil
+}
+
+func (setup *BenchmarkSetup) runBenchmark() (Benchmark, error) {
+	benchmark := Benchmark{}
+
+	// Test latency
+	latency, err := utils.TestSpeedWithSystemProxy(setup.BaseURL, 5)
+	if err != nil {
+		return benchmark, fmt.Errorf("error testing latency: %v", err)
+	}
+	benchmark.Latency = latency
+
+	for _, concurrency := range setup.ConcurrencyLevels {
+		measurement, err := setup.measureConcurrency(latency, concurrency)
+		if err != nil {
+			return benchmark, fmt.Errorf("concurrency %d measurement error: %v", concurrency, err)
+		}
+
+		benchmark.Measurements = append(benchmark.Measurements, measurement)
+	}
+
+	return benchmark, nil
+}
+
+func (setup *BenchmarkSetup) measureConcurrency(latency float64, concurrency int) (utils.Measurement, error) {
+	measurementSetup := utils.MeasurementSetup{
+		BaseUrl:     setup.BaseURL,
+		ApiKey:      setup.ApiKey,
+		ModelName:   setup.ModelName,
+		Prompt:      setup.Prompt,
+		NumWords:    setup.NumWords,
+		MaxTokens:   setup.MaxTokens,
+		Latency:     latency,
+		Concurrency: concurrency,
+	}
+	if setup.UseRandomInput {
+		measurementSetup.UseRandomInput = true
+	}
+
+	var measurement utils.Measurement
+	measurement = measurementSetup.MeasureSpeed()
+	return measurement, nil
+}

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func (benchmark *Benchmark) Json() (string, error) {
+	prettyJSON, err := json.MarshalIndent(benchmark, "", "    ")
+	if err != nil {
+		return "", fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	return string(prettyJSON), nil
+}
+
+func (benchmark *Benchmark) Yaml() (string, error) {
+	yamlData, err := yaml.Marshal(&benchmark)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling yaml: %v", err)
+	}
+
+	return string(yamlData), nil
+}

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
-func (benchmark *Benchmark) Json() (string, error) {
+func (benchmark *BenchmarkResult) Json() (string, error) {
 	prettyJSON, err := json.MarshalIndent(benchmark, "", "    ")
 	if err != nil {
 		return "", fmt.Errorf("error marshalling JSON: %w", err)
@@ -16,7 +16,7 @@ func (benchmark *Benchmark) Json() (string, error) {
 	return string(prettyJSON), nil
 }
 
-func (benchmark *Benchmark) Yaml() (string, error) {
+func (benchmark *BenchmarkResult) Yaml() (string, error) {
 	yamlData, err := yaml.Marshal(&benchmark)
 	if err != nil {
 		return "", fmt.Errorf("error marshalling yaml: %v", err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ func main() {
 	numWords := pflag.IntP("num-words", "n", 0, "Number of words Input")
 	concurrencyStr := pflag.StringP("concurrency", "c", "1,2,4,8,16,32,64,128", "Comma-separated list of concurrency levels")
 	maxTokens := pflag.IntP("max-tokens", "t", 512, "Maximum number of tokens to generate")
+	format := pflag.StringP("format", "f", "", "Output format")
 	help := pflag.BoolP("help", "h", false, "Show this help message")
 	pflag.Parse()
 
@@ -28,14 +29,22 @@ func main() {
 		os.Exit(0)
 	}
 
+	benchmarkSetup := BenchmarkSetup{}
+	benchmarkSetup.BaseURL = *baseURL
+	benchmarkSetup.ApiKey = *apiKey
+	benchmarkSetup.ModelName = *model
+	benchmarkSetup.Prompt = *prompt
+	benchmarkSetup.NumWords = *numWords
+	benchmarkSetup.MaxTokens = *maxTokens
+
 	// Parse concurrency levels
 	concurrencyLevels, err := utils.ParseConcurrencyLevels(*concurrencyStr)
 	if err != nil {
 		log.Fatalf("Invalid concurrency levels: %v", err)
 	}
+	benchmarkSetup.ConcurrencyLevels = concurrencyLevels
 
 	// Initialize OpenAI client
-	var modelName string
 	config := openai.DefaultConfig(*apiKey)
 	config.BaseURL = *baseURL
 	client := openai.NewClientWithConfig(config)
@@ -47,80 +56,56 @@ func main() {
 			log.Printf("Error discovering model: %v", err)
 			return
 		}
-		modelName = discoveredModel
-	} else {
-		modelName = *model
+		benchmarkSetup.ModelName = discoveredModel
 	}
 
 	// Determine input parameters and call benchmark function
-	var inputTokens int
-	var useRandomInput bool
-
 	if *prompt != "Write a long story, no less than 10,000 words, starting from a long, long time ago." {
-		useRandomInput = false
+		benchmarkSetup.UseRandomInput = false
 	} else if *numWords != 0 {
-		useRandomInput = true
+		benchmarkSetup.UseRandomInput = true
 	} else {
-		useRandomInput = false
+		benchmarkSetup.UseRandomInput = false
 	}
 
 	// Get input tokens
-	if useRandomInput {
-		resp, err := api.AskOpenAIwithRandomInputNonStream(client, modelName, *numWords/4, 4)
+	if benchmarkSetup.UseRandomInput {
+		resp, err := api.AskOpenAIwithRandomInputNonStream(client, benchmarkSetup.ModelName, *numWords/4, 4)
 		if err != nil {
 			log.Fatalf("Error getting prompt tokens: %v", err)
 		}
-		inputTokens = resp.Usage.PromptTokens
+		benchmarkSetup.InputTokens = resp.Usage.PromptTokens
 	} else {
-		resp, err := api.AskOpenAINonStream(client, modelName, *prompt, 4)
+		resp, err := api.AskOpenAINonStream(client, benchmarkSetup.ModelName, *prompt, 4)
 		if err != nil {
 			log.Fatalf("Error getting prompt tokens: %v", err)
 		}
-		inputTokens = resp.Usage.PromptTokens
+		benchmarkSetup.InputTokens = resp.Usage.PromptTokens
 	}
 
-	runBenchmark(*baseURL, *apiKey, modelName, *prompt, inputTokens, *maxTokens, concurrencyLevels, useRandomInput, *numWords)
-}
-
-func runBenchmark(baseURL, apiKey, modelName, prompt string, inputTokens, maxTokens int, concurrencyLevels []int, useRandomInput bool, numWords int) {
-	// Test latency
-	latency, err := utils.TestSpeedWithSystemProxy(baseURL, 5)
-	if err != nil {
-		log.Printf("Latency test error: %v", err)
-		latency = 0
-	}
-
-	// Print benchmark header
-	utils.PrintBenchmarkHeader(modelName, inputTokens, maxTokens, latency)
-
-	// Print table header
-	fmt.Println("| Concurrency | Generation Throughput (tokens/s) |  Prompt Throughput (tokens/s) | Min TTFT (s) | Max TTFT (s) |")
-	fmt.Println("|-------------|----------------------------------|-------------------------------|--------------|--------------|")
-
-	// Test each concurrency level and print results
-	var results [][]interface{}
-	for _, concurrency := range concurrencyLevels {
-		var generationSpeed, promptThroughput, maxTTFT, minTTFT float64
-		if useRandomInput {
-			generationSpeed, promptThroughput, maxTTFT, minTTFT = utils.MeasureSpeedwithRandomInput(baseURL, apiKey, modelName, numWords/4, concurrency, maxTokens, latency)
-		} else {
-			generationSpeed, promptThroughput, maxTTFT, minTTFT = utils.MeasureSpeed(baseURL, apiKey, modelName, prompt, concurrency, maxTokens, latency)
+	if *format == "" {
+		err := benchmarkSetup.runBenchmarkCli()
+		if err != nil {
+			log.Fatalf("Error running benchmark: %v", err)
+		}
+	} else {
+		result, err := benchmarkSetup.runBenchmark()
+		if err != nil {
+			log.Fatalf("Error running benchmark: %v", err)
 		}
 
-		// Print current results
-		fmt.Printf("| %11d | %32.2f | %29.2f | %12.2f | %12.2f |\n",
-			concurrency,
-			generationSpeed,
-			promptThroughput,
-			minTTFT,
-			maxTTFT)
-
-		// Save results for later
-		results = append(results, []interface{}{concurrency, generationSpeed, promptThroughput, minTTFT, maxTTFT})
+		var output string
+		switch *format {
+		case "json":
+			output, err = result.Json()
+		case "yaml":
+			output, err = result.Yaml()
+		default:
+			output, err = result.Json()
+		}
+		if err != nil {
+			log.Fatalf("Error formatting benchmark: %v", err)
+		}
+		fmt.Println(output)
 	}
-
-	fmt.Println("\n================================================================================================================")
-
-	// Save results to Markdown
-	utils.SaveResultsToMD(results, modelName, inputTokens, maxTokens, latency)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,15 +11,19 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const (
+	defaultPrompt = "Write a long story, no less than 10,000 words, starting from a long, long time ago."
+)
+
 func main() {
 	baseURL := pflag.StringP("base-url", "u", "", "Base URL of the OpenAI API")
 	apiKey := pflag.StringP("api-key", "k", "", "API key for authentication")
 	model := pflag.StringP("model", "m", "", "Model to be used for the requests (optional)")
-	prompt := pflag.StringP("prompt", "p", "Write a long story, no less than 10,000 words, starting from a long, long time ago.", "Prompt to be used for generating responses")
-	numWords := pflag.IntP("num-words", "n", 0, "Number of words Input")
+	prompt := pflag.StringP("prompt", "p", defaultPrompt, "Prompt to be used for generating responses")
+	numWords := pflag.IntP("num-words", "n", 0, "If set to a value above 0 a random string with this length will be used as prompt")
 	concurrencyStr := pflag.StringP("concurrency", "c", "1,2,4,8,16,32,64,128", "Comma-separated list of concurrency levels")
 	maxTokens := pflag.IntP("max-tokens", "t", 512, "Maximum number of tokens to generate")
-	format := pflag.StringP("format", "f", "", "Output format")
+	format := pflag.StringP("format", "f", "", "Output format (optional)")
 	help := pflag.BoolP("help", "h", false, "Show this help message")
 	pflag.Parse()
 
@@ -29,22 +33,26 @@ func main() {
 		os.Exit(0)
 	}
 
-	benchmarkSetup := BenchmarkSetup{}
-	benchmarkSetup.BaseURL = *baseURL
-	benchmarkSetup.ApiKey = *apiKey
-	benchmarkSetup.ModelName = *model
-	benchmarkSetup.Prompt = *prompt
-	benchmarkSetup.NumWords = *numWords
-	benchmarkSetup.MaxTokens = *maxTokens
+	// Create benchmark
+	benchmark := Benchmark{}
+	benchmark.BaseURL = *baseURL
+	benchmark.ApiKey = *apiKey
+	benchmark.ModelName = *model
+	benchmark.Prompt = *prompt
+	benchmark.NumWords = *numWords
+	benchmark.MaxTokens = *maxTokens
 
 	// Parse concurrency levels
 	concurrencyLevels, err := utils.ParseConcurrencyLevels(*concurrencyStr)
 	if err != nil {
 		log.Fatalf("Invalid concurrency levels: %v", err)
 	}
-	benchmarkSetup.ConcurrencyLevels = concurrencyLevels
+	benchmark.ConcurrencyLevels = concurrencyLevels
 
 	// Initialize OpenAI client
+	if *baseURL == "" {
+		log.Fatalf("--base-url is required")
+	}
 	config := openai.DefaultConfig(*apiKey)
 	config.BaseURL = *baseURL
 	client := openai.NewClientWithConfig(config)
@@ -56,40 +64,40 @@ func main() {
 			log.Printf("Error discovering model: %v", err)
 			return
 		}
-		benchmarkSetup.ModelName = discoveredModel
+		benchmark.ModelName = discoveredModel
 	}
 
 	// Determine input parameters and call benchmark function
 	if *prompt != "Write a long story, no less than 10,000 words, starting from a long, long time ago." {
-		benchmarkSetup.UseRandomInput = false
+		benchmark.UseRandomInput = false
 	} else if *numWords != 0 {
-		benchmarkSetup.UseRandomInput = true
+		benchmark.UseRandomInput = true
 	} else {
-		benchmarkSetup.UseRandomInput = false
+		benchmark.UseRandomInput = false
 	}
 
 	// Get input tokens
-	if benchmarkSetup.UseRandomInput {
-		resp, err := api.AskOpenAIwithRandomInputNonStream(client, benchmarkSetup.ModelName, *numWords/4, 4)
+	if benchmark.UseRandomInput {
+		resp, err := api.AskOpenAiWithRandomInput(client, benchmark.ModelName, *numWords/4, 4)
 		if err != nil {
 			log.Fatalf("Error getting prompt tokens: %v", err)
 		}
-		benchmarkSetup.InputTokens = resp.Usage.PromptTokens
+		benchmark.InputTokens = resp.Usage.PromptTokens
 	} else {
-		resp, err := api.AskOpenAINonStream(client, benchmarkSetup.ModelName, *prompt, 4)
+		resp, err := api.AskOpenAi(client, benchmark.ModelName, *prompt, 4)
 		if err != nil {
 			log.Fatalf("Error getting prompt tokens: %v", err)
 		}
-		benchmarkSetup.InputTokens = resp.Usage.PromptTokens
+		benchmark.InputTokens = resp.Usage.PromptTokens
 	}
 
 	if *format == "" {
-		err := benchmarkSetup.runBenchmarkCli()
+		err := benchmark.runCli()
 		if err != nil {
 			log.Fatalf("Error running benchmark: %v", err)
 		}
 	} else {
-		result, err := benchmarkSetup.runBenchmark()
+		result, err := benchmark.run()
 		if err != nil {
 			log.Fatalf("Error running benchmark: %v", err)
 		}
@@ -101,10 +109,10 @@ func main() {
 		case "yaml":
 			output, err = result.Yaml()
 		default:
-			output, err = result.Json()
+			log.Printf("Invalid format specified")
 		}
 		if err != nil {
-			log.Fatalf("Error formatting benchmark: %v", err)
+			log.Fatalf("Error formatting benchmark result: %v", err)
 		}
 		fmt.Println(output)
 	}

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -2,22 +2,22 @@ package main
 
 import "github.com/Yoosu-L/llmapibenchmark/internal/utils"
 
-type BenchmarkSetup struct {
-	BaseURL           string `json:"base_url"`
-	ApiKey            string `json:"api_key"`
-	ModelName         string `json:"model_name"`
-	Prompt            string `json:"prompt"`
-	InputTokens       int    `json:"input_tokens"`
-	MaxTokens         int    `json:"max_tokens"`
-	ConcurrencyLevels []int  `json:"concurrency_levels"`
-	UseRandomInput    bool   `json:"use_random_input"`
-	NumWords          int    `json:"num_words"`
+type Benchmark struct {
+	BaseURL           string
+	ApiKey            string
+	ModelName         string
+	Prompt            string
+	InputTokens       int
+	MaxTokens         int
+	ConcurrencyLevels []int
+	UseRandomInput    bool
+	NumWords          int
 }
 
-type Benchmark struct {
-	ModelName    string
-	InputTokens  int
-	MaxTokens    int
-	Latency      float64
-	Measurements []utils.Measurement
+type BenchmarkResult struct {
+	ModelName   string              `json:"model_name" yaml:"model-name"`
+	InputTokens int                 `json:"input_tokens" yaml:"input-tokens"`
+	MaxTokens   int                 `json:"max_tokens" yaml:"max-tokens"`
+	Latency     float64             `json:"latency" yaml:"latency"`
+	Results     []utils.SpeedResult `json:"results" yaml:"results"`
 }

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -17,7 +17,7 @@ type Benchmark struct {
 type BenchmarkResult struct {
 	ModelName   string              `json:"model_name" yaml:"model-name"`
 	InputTokens int                 `json:"input_tokens" yaml:"input-tokens"`
-	MaxTokens   int                 `json:"max_tokens" yaml:"max-tokens"`
+	MaxTokens   int                 `json:"output_tokens" yaml:"output-tokens"` // Historically been called Output Tokens
 	Latency     float64             `json:"latency" yaml:"latency"`
 	Results     []utils.SpeedResult `json:"results" yaml:"results"`
 }

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -1,0 +1,23 @@
+package main
+
+import "github.com/Yoosu-L/llmapibenchmark/internal/utils"
+
+type BenchmarkSetup struct {
+	BaseURL           string `json:"base_url"`
+	ApiKey            string `json:"api_key"`
+	ModelName         string `json:"model_name"`
+	Prompt            string `json:"prompt"`
+	InputTokens       int    `json:"input_tokens"`
+	MaxTokens         int    `json:"max_tokens"`
+	ConcurrencyLevels []int  `json:"concurrency_levels"`
+	UseRandomInput    bool   `json:"use_random_input"`
+	NumWords          int    `json:"num_words"`
+}
+
+type Benchmark struct {
+	ModelName    string
+	InputTokens  int
+	MaxTokens    int
+	Latency      float64
+	Measurements []utils.Measurement
+}

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.23.3
 require (
 	github.com/sashabaranov/go-openai v1.41.1
 	github.com/spf13/pflag v1.0.7
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v4 v4.0.0-rc.1
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Yoosu-L/llmapibenchmark
 go 1.23.3
 
 require (
-	github.com/sashabaranov/go-openai v1.41.1 // indirect
-	github.com/spf13/pflag v1.0.7 // indirect
+	github.com/sashabaranov/go-openai v1.41.1
+	github.com/spf13/pflag v1.0.7
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,5 @@ github.com/sashabaranov/go-openai v1.41.1 h1:zf5tM+GuxpyiyD9XZg8nCqu52eYFQg9OOew
 github.com/sashabaranov/go-openai v1.41.1/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
 github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+go.yaml.in/yaml/v4 v4.0.0-rc.1 h1:4J1+yLKUIPGexM/Si+9d3pij4hdc7aGO04NhrElqXbY=
+go.yaml.in/yaml/v4 v4.0.0-rc.1/go.mod h1:CBdeces52/nUXndfQ5OY8GEQuNR9uEEOJPZj/Xq5IzU=

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,7 @@ github.com/sashabaranov/go-openai v1.41.1 h1:zf5tM+GuxpyiyD9XZg8nCqu52eYFQg9OOew
 github.com/sashabaranov/go-openai v1.41.1/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
 github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/utils/latency.go
+++ b/internal/utils/latency.go
@@ -7,8 +7,8 @@ import (
 	"time"
 )
 
-// TestSpeedWithSystemProxy tests the network latency to a given base URL.
-func TestSpeedWithSystemProxy(baseURL string, attempts int) (float64, error) {
+// MeasureLatency tests the network latency to a given base URL.
+func MeasureLatency(baseURL string, attempts int) (float64, error) {
 	if baseURL == "" {
 		return 0, fmt.Errorf("empty base URL")
 	}

--- a/internal/utils/speed.go
+++ b/internal/utils/speed.go
@@ -10,76 +10,29 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
-// MeasureSpeed measures API generation throughput and TTFT.
-func MeasureSpeed(baseURL, apiKey, model, prompt string, concurrency, maxTokens int, latency float64) (float64, float64, float64, float64) {
-	config := openai.DefaultConfig(apiKey)
-	config.BaseURL = baseURL
-	client := openai.NewClientWithConfig(config)
-
-	var wg sync.WaitGroup
-	var responseTokens sync.Map
-	var promptTokens sync.Map
-	var ttfts sync.Map
-
-	start := time.Now()
-
-	// Send requests concurrently
-	for i := 0; i < concurrency; i++ {
-		wg.Add(1)
-		go func(index int) {
-			defer wg.Done()
-			ttft, completionTokens, inputTokens, err := api.AskOpenAI(client, model, prompt, maxTokens)
-			if err != nil {
-				return
-			}
-			ttfts.Store(index, ttft)
-			responseTokens.Store(index, completionTokens)
-			promptTokens.Store(index, inputTokens)
-		}(i)
-	}
-
-	wg.Wait()
-	duration := time.Since(start)
-
-	// Calculate total tokens
-	totalResponseTokens := 0
-	responseTokens.Range(func(_, value interface{}) bool {
-		totalResponseTokens += value.(int)
-		return true
-	})
-
-	totalPromptTokens := 0
-	promptTokens.Range(func(_, value interface{}) bool {
-		totalPromptTokens += value.(int)
-		return true
-	})
-
-	// Calculate max and min TTFT
-	maxTTFT := 0.0
-	minTTFT := math.Inf(1)
-	ttfts.Range(func(_, value interface{}) bool {
-		ttft := value.(float64)
-		if ttft > maxTTFT {
-			maxTTFT = ttft
-		}
-		if ttft < minTTFT {
-			minTTFT = ttft
-		}
-		return true
-	})
-
-	// Calculate speed (tokens/second)
-	generationSpeed := float64(totalResponseTokens) / (duration.Seconds() - latency/1000)
-
-	// Calculate Prompt Throughput
-	promptThroughput := float64(totalPromptTokens) / (maxTTFT - latency/1000)
-
-	return generationSpeed, promptThroughput, maxTTFT, minTTFT
+type MeasurementSetup struct {
+	BaseUrl        string
+	ApiKey         string
+	ModelName      string
+	Prompt         string
+	UseRandomInput bool
+	NumWords       int
+	MaxTokens      int
+	Latency        float64
+	Concurrency    int
 }
 
-func MeasureSpeedwithRandomInput(baseURL, apiKey, model string, numWords int, concurrency, maxTokens int, latency float64) (float64, float64, float64, float64) {
-	config := openai.DefaultConfig(apiKey)
-	config.BaseURL = baseURL
+type Measurement struct {
+	GenerationSpeed  float64 `json:"generation_speed"`
+	PromptThroughput float64 `json:"prompt_throughput"`
+	MaxTtft          float64 `json:"max_ttft"`
+	MinTtft          float64 `json:"min_ttft"`
+}
+
+// MeasureSpeed measures API generation throughput and TTFT.
+func (setup *MeasurementSetup) MeasureSpeed() Measurement {
+	config := openai.DefaultConfig(setup.ApiKey)
+	config.BaseURL = setup.BaseUrl
 	client := openai.NewClientWithConfig(config)
 
 	var wg sync.WaitGroup
@@ -90,12 +43,20 @@ func MeasureSpeedwithRandomInput(baseURL, apiKey, model string, numWords int, co
 	start := time.Now()
 
 	// Send requests concurrently
-	for i := 0; i < concurrency; i++ {
+	for i := 0; i < setup.Concurrency; i++ {
 		wg.Add(1)
 		go func(index int) {
 			defer wg.Done()
-			ttft, completionTokens, inputTokens, err := api.AskOpenAIwithRandomInput(client, model, numWords, maxTokens)
+			var ttft float64
+			var completionTokens, inputTokens int
+			var err error
+			if setup.UseRandomInput {
+				ttft, completionTokens, inputTokens, err = api.AskOpenAIwithRandomInput(client, setup.ModelName, setup.NumWords, setup.MaxTokens)
+			} else {
+				ttft, completionTokens, inputTokens, err = api.AskOpenAI(client, setup.ModelName, setup.Prompt, setup.MaxTokens)
+			}
 			if err != nil {
+				// TODO use a mutex to store err and handle in outer thread
 				return
 			}
 			ttfts.Store(index, ttft)
@@ -120,25 +81,27 @@ func MeasureSpeedwithRandomInput(baseURL, apiKey, model string, numWords int, co
 		return true
 	})
 
+	measurement := Measurement{}
+
 	// Calculate max and min TTFT
-	maxTTFT := 0.0
-	minTTFT := math.Inf(1)
+	measurement.MaxTtft = 0.0
+	measurement.MinTtft = math.Inf(1)
 	ttfts.Range(func(_, value interface{}) bool {
 		ttft := value.(float64)
-		if ttft > maxTTFT {
-			maxTTFT = ttft
+		if ttft > measurement.MaxTtft {
+			measurement.MaxTtft = ttft
 		}
-		if ttft < minTTFT {
-			minTTFT = ttft
+		if ttft < measurement.MinTtft {
+			measurement.MinTtft = ttft
 		}
 		return true
 	})
 
 	// Calculate speed (tokens/second)
-	generationSpeed := float64(totalResponseTokens) / (duration.Seconds() - latency/1000)
+	measurement.GenerationSpeed = float64(totalResponseTokens) / (duration.Seconds() - setup.Latency/1000)
 
 	// Calculate Prompt Throughput
-	promptThroughput := float64(totalPromptTokens) / (maxTTFT - latency/1000)
+	measurement.PromptThroughput = float64(totalPromptTokens) / (measurement.MaxTtft - setup.Latency/1000)
 
-	return generationSpeed, promptThroughput, maxTTFT, minTTFT
+	return measurement
 }


### PR DESCRIPTION
* Resolves #2 
* Add `format` flag and handle json and yaml (maybe csv in future)
* Refactor duplicate functions
* Use functions on structs rather than passing many arguments


```
~/llmapibenchmark/cmd$ go run . --base-url http://192.168.86.86:8080/v3 --model myModel --concurrency 1,2

################################################################################################################
                                          LLM API Throughput Benchmark
                                    https://github.com/Yoosu-L/llmapibenchmark
                                         Time：2025-08-13 13:10:55 UTC+0
################################################################################################################
Input Tokens: 37
Output Tokens: 512
Test Model: myModel
Latency: 5.80 ms

| Concurrency | Generation Throughput (tokens/s) |  Prompt Throughput (tokens/s) | Min TTFT (s) | Max TTFT (s) |
|-------------|----------------------------------|-------------------------------|--------------|--------------|
|           1 |                            36.58 |                        189.63 |         0.17 |         0.17 |
|           2 |                            51.14 |                        192.61 |         0.33 |         0.33 |

================================================================================================================
Results saved to: API_Throughput_myModel.md

~/llmapibenchmark/cmd$ go run . --base-url http://192.168.86.86:8080/v3 --model myModel --concurrency 1,2 --format json
{
    "model_name": "myModel",
    "input_tokens": 37,
    "max_tokens": 512,
    "latency": 5.6,
    "results": [
        {
            "concurrency": 1,
            "generation_speed": 35.487790702441316,
            "prompt_throughput": 186.8995993559898,
            "max_ttft": 0.171464454,
            "min_ttft": 0.171464454
        },
        {
            "concurrency": 2,
            "generation_speed": 50.599297893768636,
            "prompt_throughput": 181.6048211838673,
            "max_ttft": 0.347000628,
            "min_ttft": 0.311559364
        }
    ]
}
~/llmapibenchmark/cmd$ go run . --base-url http://192.168.86.86:8080/v3 --model myModel --concurrency 1,2 --format yaml
model-name: myModel
input-tokens: 37
max-tokens: 512
latency: 6
results:
    - concurrency: 1
      generation-speed: 36.25682147319934
      prompt-throughput: 187.73328661721706
      max-ttft: 0.171127882
      min-ttft: 0.171127882
    - concurrency: 2
      generation-speed: 52.927612655227755
      prompt-throughput: 198.22007199340226
      max-ttft: 0.318783662
      min-ttft: 0.285803633

```