### PR TITLE
Always use stream and show progress

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,9 +79,9 @@ func main() {
 	// Get input tokens
 	var inputTokens int
 	if benchmark.UseRandomInput {
-		_, _, inputTokens, err = api.AskOpenAiStreamWithRandomInput(client, benchmark.ModelName, *numWords/4, 4)
+		_, _, inputTokens, err = api.AskOpenAiWithRandomInput(client, benchmark.ModelName, *numWords/4, 4)
 	} else {
-		_, _, inputTokens, err = api.AskOpenAiStream(client, benchmark.ModelName, *prompt, 4)
+		_, _, inputTokens, err = api.AskOpenAi(client, benchmark.ModelName, *prompt, 4)
 	}
 	if err != nil {
 		log.Fatalf("Error getting input token count: %v", err)

--- a/internal/api/api_client.go
+++ b/internal/api/api_client.go
@@ -12,8 +12,8 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
-// AskOpenAiStream sends a prompt to the OpenAI API, processes the response stream and returns stats on it.
-func AskOpenAiStream(client *openai.Client, model string, prompt string, maxTokens int) (float64, int, int, error) {
+// AskOpenAi sends a prompt to the OpenAI API, processes the response stream and returns stats on it.
+func AskOpenAi(client *openai.Client, model string, prompt string, maxTokens int) (float64, int, int, error) {
 	start := time.Now()
 
 	var (
@@ -87,9 +87,9 @@ func AskOpenAiStream(client *openai.Client, model string, prompt string, maxToke
 	return timeToFirstToken, completionTokens, promptTokens, nil
 }
 
-func AskOpenAiStreamWithRandomInput(client *openai.Client, model string, numWords int, maxTokens int) (float64, int, int, error) {
+func AskOpenAiWithRandomInput(client *openai.Client, model string, numWords int, maxTokens int) (float64, int, int, error) {
 	prompt := generateRandomPhrase(numWords)
-	return AskOpenAiStream(client, model, prompt, maxTokens)
+	return AskOpenAi(client, model, prompt, maxTokens)
 }
 
 // GetFirstAvailableModel retrieves the first available model from the OpenAI API.

--- a/internal/utils/speed.go
+++ b/internal/utils/speed.go
@@ -58,9 +58,9 @@ func (setup *SpeedMeasurement) Run() (SpeedResult, error) {
 			var completionTokens, inputTokens int
 			var err error
 			if setup.UseRandomInput {
-				ttft, completionTokens, inputTokens, err = api.AskOpenAiStreamWithRandomInput(client, setup.ModelName, setup.NumWords, setup.MaxTokens)
+				ttft, completionTokens, inputTokens, err = api.AskOpenAiWithRandomInput(client, setup.ModelName, setup.NumWords, setup.MaxTokens)
 			} else {
-				ttft, completionTokens, inputTokens, err = api.AskOpenAiStream(client, setup.ModelName, setup.Prompt, setup.MaxTokens)
+				ttft, completionTokens, inputTokens, err = api.AskOpenAi(client, setup.ModelName, setup.Prompt, setup.MaxTokens)
 			}
 			if err != nil {
 				threadErrors.Store(index, err)


### PR DESCRIPTION
* ~Fix a bug where getting input token count would not limit response tokens and take a long time. Some servers do not yet support `MaxCompletionTokens`, so we need to also define `MaxTokens`.~ _Already fixed upstream_
* Always use streamed response api, halving api code to maintain
* Add DEBUG env var that will print progress of streamed responses. This is useful when running in CI, on slow hosts, where the benchmark will run for a long time without any output - which could trigger watchdog logic.