### PR TITLE
Progress during json and yaml

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,17 +78,17 @@ func main() {
 
 	// Get input tokens
 	if benchmark.UseRandomInput {
-		resp, err := api.AskOpenAiWithRandomInput(client, benchmark.ModelName, *numWords/4, 4)
+		_, _, promptTokens, err := api.AskOpenAiRandomInput(client, benchmark.ModelName, *numWords/4, 4, nil)
 		if err != nil {
 			log.Fatalf("Error getting prompt tokens: %v", err)
 		}
-		benchmark.InputTokens = resp.Usage.PromptTokens
+		benchmark.InputTokens = promptTokens
 	} else {
-		resp, err := api.AskOpenAi(client, benchmark.ModelName, *prompt, 4)
+		_, _, promptTokens, err := api.AskOpenAi(client, benchmark.ModelName, *prompt, 4, nil)
 		if err != nil {
 			log.Fatalf("Error getting prompt tokens: %v", err)
 		}
-		benchmark.InputTokens = resp.Usage.PromptTokens
+		benchmark.InputTokens = promptTokens
 	}
 
 	if *format == "" {

--- a/internal/api/api_client.go
+++ b/internal/api/api_client.go
@@ -12,87 +12,16 @@ import (
 	"github.com/schollz/progressbar/v3"
 )
 
-// AskOpenAiStream sends a prompt to the OpenAI API, processes the response stream and returns stats on it.
-func AskOpenAiStream(client *openai.Client, model string, prompt string, maxTokens int) (float64, int, int, error) {
+// AskOpenAi sends a prompt to the OpenAI API, processes the response stream and returns stats on it.
+func AskOpenAi(client *openai.Client, model string, prompt string, maxTokens int, bar *progressbar.ProgressBar) (float64, int, int, error) {
 	start := time.Now()
 
 	var (
-		timeToFirstToken float64
-		firstTokenSeen   bool
-		lastUsage        *openai.Usage
-	)
-
-	stream, err := client.CreateChatCompletionStream(
-		context.Background(),
-		openai.ChatCompletionRequest{
-			Model: model,
-			Messages: []openai.ChatCompletionMessage{
-				{
-					Role:    openai.ChatMessageRoleUser,
-					Content: prompt,
-				},
-			},
-			// Add the deprecated `MaxTokens` for backward compatibility with some older API servers.
-			MaxTokens:           maxTokens,
-			MaxCompletionTokens: maxTokens,
-			Temperature:         1,
-			Stream:              true,
-			StreamOptions: &openai.StreamOptions{
-				IncludeUsage: true,
-			},
-		},
-	)
-	if err != nil {
-		return 0, 0, 0, fmt.Errorf("OpenAI API request failed: %w", err)
-	}
-	defer stream.Close()
-
-	for {
-		resp, err := stream.Recv()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		if err != nil {
-			return 0, 0, 0, fmt.Errorf("stream error: %w", err)
-		}
-
-		if !firstTokenSeen && len(resp.Choices) > 0 {
-			content := resp.Choices[0].Delta.Content
-			if strings.TrimSpace(content) != "" {
-				timeToFirstToken = time.Since(start).Seconds()
-				firstTokenSeen = true
-			}
-		}
-
-		if resp.Usage != nil {
-			lastUsage = resp.Usage
-		}
-	}
-
-	var promptTokens, completionTokens int
-	if lastUsage != nil {
-		promptTokens = lastUsage.PromptTokens
-		completionTokens = lastUsage.CompletionTokens
-	}
-
-	return timeToFirstToken, completionTokens, promptTokens, nil
-}
-
-func AskOpenAiStreamWithRandomInput(client *openai.Client, model string, numWords int, maxTokens int) (float64, int, int, error) {
-	prompt := generateRandomPhrase(numWords)
-	return AskOpenAiStream(client, model, prompt, maxTokens)
-}
-
-// AskOpenAiStreamWithProgress sends a prompt to the OpenAI API with progress bar updates.
-func AskOpenAiStreamWithProgress(client *openai.Client, model string, prompt string, maxTokens int, bar *progressbar.ProgressBar) (float64, int, int, error) {
-	start := time.Now()
-
-	var (
-		timeToFirstToken float64
-		firstTokenSeen   bool
-		lastUsage        *openai.Usage
+		timeToFirstToken   float64
+		firstTokenSeen     bool
+		lastUsage          *openai.Usage
 		accumulatedContent string // Accumulate all content to count tokens more accurately
-		estimatedTokens  int      // Real-time token estimation
+		estimatedTokens    int    // Real-time token estimation
 	)
 
 	stream, err := client.CreateChatCompletionStream(
@@ -137,16 +66,16 @@ func AskOpenAiStreamWithProgress(client *openai.Client, model string, prompt str
 			}
 		}
 
-		// Process each chunk and estimate tokens in real-time
+		// Process each chunk, accumulating to response content
 		if len(resp.Choices) > 0 {
 			content := resp.Choices[0].Delta.Content
 			if content != "" {
 				accumulatedContent += content
-				
-				// Improved token estimation based on content characteristics
-				newTokens := estimateTokensFromContent(content)
+
+				// Estimate number of tokens in current chunk
+				newTokens := estimateTokens(content)
 				estimatedTokens += newTokens
-				
+
 				if bar != nil {
 					bar.Add(newTokens)
 				}
@@ -162,7 +91,7 @@ func AskOpenAiStreamWithProgress(client *openai.Client, model string, prompt str
 	if lastUsage != nil {
 		promptTokens = lastUsage.PromptTokens
 		completionTokens = lastUsage.CompletionTokens
-		
+
 		// Final adjustment: if we have actual completion tokens, adjust the progress bar
 		if bar != nil && completionTokens > 0 {
 			diff := completionTokens - estimatedTokens
@@ -178,22 +107,25 @@ func AskOpenAiStreamWithProgress(client *openai.Client, model string, prompt str
 	return timeToFirstToken, completionTokens, promptTokens, nil
 }
 
-// estimateTokensFromContent provides more accurate token estimation based on content
-func estimateTokensFromContent(content string) int {
+func AskOpenAiRandomInput(client *openai.Client, model string, numWords int, maxTokens int, bar *progressbar.ProgressBar) (float64, int, int, error) {
+	prompt := generateRandomPhrase(numWords)
+	return AskOpenAi(client, model, prompt, maxTokens, bar)
+}
+
+func estimateTokens(content string) int {
 	if content == "" {
 		return 0
 	}
-	
-	// More sophisticated token estimation algorithm
+
 	content = strings.TrimSpace(content)
 	if len(content) == 0 {
 		return 0
 	}
-	
-	// Different strategies based on content type
+
 	words := strings.Fields(content)
 	wordCount := len(words)
-	
+
+	// Different strategies based on content type
 	if wordCount > 0 {
 		// For text with clear word boundaries: ~1.3 tokens per word on average
 		// This accounts for subword tokenization in modern models
@@ -202,62 +134,8 @@ func estimateTokensFromContent(content string) int {
 		// For content without clear word boundaries (like punctuation, single chars)
 		// Use character-based estimation: ~3-4 characters per token
 		charCount := len(content)
-		return max(1, charCount/3)
+		return max(1, int(float64(charCount)/3.0))
 	}
-}
-
-// Helper function for min
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-// Helper function for Go versions that might not have max built-in
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func AskOpenAiStreamWithRandomInputAndProgress(client *openai.Client, model string, numWords int, maxTokens int, bar *progressbar.ProgressBar) (float64, int, int, error) {
-	prompt := generateRandomPhrase(numWords)
-	return AskOpenAiStreamWithProgress(client, model, prompt, maxTokens, bar)
-}
-
-// AskOpenAi sends a prompt to the OpenAI API and returns the response, not using streaming.
-func AskOpenAi(client *openai.Client, model, prompt string, maxTokens int) (*openai.ChatCompletionResponse, error) {
-	resp, err := client.CreateChatCompletion(
-		context.Background(),
-		openai.ChatCompletionRequest{
-			Model: model,
-			Messages: []openai.ChatCompletionMessage{
-				{
-					Role:    openai.ChatMessageRoleSystem,
-					Content: "You are a helpful assistant.",
-				},
-				{
-					Role:    openai.ChatMessageRoleUser,
-					Content: prompt,
-				},
-			},
-			// Add the deprecated `MaxTokens` for backward compatibility with some older API servers.
-			MaxTokens:           maxTokens,
-			MaxCompletionTokens: maxTokens,
-			Temperature:         1,
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("OpenAI API request failed: %w", err)
-	}
-	return &resp, nil
-}
-
-func AskOpenAiWithRandomInput(client *openai.Client, model string, numWords int, maxTokens int) (*openai.ChatCompletionResponse, error) {
-	prompt := generateRandomPhrase(numWords)
-	return AskOpenAi(client, model, prompt, maxTokens)
 }
 
 // GetFirstAvailableModel retrieves the first available model from the OpenAI API.

--- a/internal/utils/speed.go
+++ b/internal/utils/speed.go
@@ -37,98 +37,7 @@ func roundToTwoDecimals(f float64) float64 {
 }
 
 // Run measures API generation throughput and TTFT.
-func (setup *SpeedMeasurement) Run() (SpeedResult, error) {
-	config := openai.DefaultConfig(setup.ApiKey)
-	config.BaseURL = setup.BaseUrl
-	client := openai.NewClientWithConfig(config)
-
-	var wg sync.WaitGroup
-	var responseTokens sync.Map
-	var promptTokens sync.Map
-	var ttfts sync.Map
-	var threadErrors sync.Map
-
-	start := time.Now()
-
-	// Send requests concurrently
-	for i := 0; i < setup.Concurrency; i++ {
-		wg.Add(1)
-		go func(index int) {
-			defer wg.Done()
-			var ttft float64
-			var completionTokens, inputTokens int
-			var err error
-			if setup.UseRandomInput {
-				ttft, completionTokens, inputTokens, err = api.AskOpenAiStreamWithRandomInput(client, setup.ModelName, setup.NumWords, setup.MaxTokens)
-			} else {
-				ttft, completionTokens, inputTokens, err = api.AskOpenAiStream(client, setup.ModelName, setup.Prompt, setup.MaxTokens)
-			}
-			if err != nil {
-				threadErrors.Store(index, err)
-				return
-			}
-			ttfts.Store(index, ttft)
-			responseTokens.Store(index, completionTokens)
-			promptTokens.Store(index, inputTokens)
-		}(i)
-	}
-
-	wg.Wait()
-	duration := time.Since(start)
-
-	// Check if any errors occurred
-	var errSlice []error
-	threadErrors.Range(func(key, value interface{}) bool {
-		errSlice = append(errSlice, value.(error))
-		return true
-	})
-	if len(errSlice) > 0 {
-		return SpeedResult{}, fmt.Errorf("error measuring speed: %v", errSlice)
-	}
-
-	// Calculate total tokens
-	totalResponseTokens := 0
-	responseTokens.Range(func(_, value interface{}) bool {
-		totalResponseTokens += value.(int)
-		return true
-	})
-
-	totalPromptTokens := 0
-	promptTokens.Range(func(_, value interface{}) bool {
-		totalPromptTokens += value.(int)
-		return true
-	})
-
-	measurement := SpeedResult{}
-	measurement.Concurrency = setup.Concurrency
-
-	// Calculate max and min TTFT
-	measurement.MaxTtft = 0.0
-	measurement.MinTtft = math.Inf(1)
-	ttfts.Range(func(_, value interface{}) bool {
-		ttft := value.(float64)
-		if ttft > measurement.MaxTtft {
-			measurement.MaxTtft = ttft
-		}
-		if ttft < measurement.MinTtft {
-			measurement.MinTtft = ttft
-		}
-		return true
-	})
-	measurement.MaxTtft = roundToTwoDecimals(measurement.MaxTtft)
-	measurement.MinTtft = roundToTwoDecimals(measurement.MinTtft)
-
-	// Calculate speed (tokens/second)
-	measurement.GenerationSpeed = roundToTwoDecimals(float64(totalResponseTokens) / (duration.Seconds() - setup.Latency/1000))
-
-	// Calculate Prompt Throughput
-	measurement.PromptThroughput = roundToTwoDecimals(float64(totalPromptTokens) / (measurement.MaxTtft - setup.Latency/1000))
-
-	return measurement, nil
-}
-
-// RunWithProgress measures API generation throughput and TTFT with progress bar updates.
-func (setup *SpeedMeasurement) RunWithProgress(bar *progressbar.ProgressBar) (SpeedResult, error) {
+func (setup *SpeedMeasurement) Run(bar *progressbar.ProgressBar) (SpeedResult, error) {
 	config := openai.DefaultConfig(setup.ApiKey)
 	config.BaseURL = setup.BaseUrl
 	client := openai.NewClientWithConfig(config)
@@ -150,9 +59,9 @@ func (setup *SpeedMeasurement) RunWithProgress(bar *progressbar.ProgressBar) (Sp
 			var completionTokens, inputTokens int
 			var err error
 			if setup.UseRandomInput {
-				ttft, completionTokens, inputTokens, err = api.AskOpenAiStreamWithRandomInputAndProgress(client, setup.ModelName, setup.NumWords, setup.MaxTokens, bar)
+				ttft, completionTokens, inputTokens, err = api.AskOpenAiRandomInput(client, setup.ModelName, setup.NumWords, setup.MaxTokens, bar)
 			} else {
-				ttft, completionTokens, inputTokens, err = api.AskOpenAiStreamWithProgress(client, setup.ModelName, setup.Prompt, setup.MaxTokens, bar)
+				ttft, completionTokens, inputTokens, err = api.AskOpenAi(client, setup.ModelName, setup.Prompt, setup.MaxTokens, bar)
 			}
 			if err != nil {
 				threadErrors.Store(index, err)


### PR DESCRIPTION
* Always show progress bar
* Remove duplicate code
* Minor changes to comments

I moved the progress bar definition into `measureSpeed` so that it is shown for both the table and the machine readable outputs. The progress is printed to stderr, while the table, json and yaml are printed to stdout.

Some of the functions are almost identical, except minor differences. I have cleaned these up.